### PR TITLE
Fix typo - markdowm should be markdown

### DIFF
--- a/about.markdown
+++ b/about.markdown
@@ -6,4 +6,4 @@ permalink: /about/
 
 Is the US trade war affecting your business? Have you received emails, watched videos, read social media posts from manufacturers & suppliers explaining how the tariffs are affecting them? Share them so we can collect and post them!
 
-Start a [discussion](https://github.com/jasoncoon/tariffsarebullshit/discussions) or submit a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models) to add new [post markdowm files](https://github.com/jasoncoon/tariffsarebullshit/tree/main/_posts).
+Start a [discussion](https://github.com/jasoncoon/tariffsarebullshit/discussions) or submit a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models) to add new [post markdown files](https://github.com/jasoncoon/tariffsarebullshit/tree/main/_posts).


### PR DESCRIPTION
This just fixes a one word typo - markdowm should probably be markdown in About